### PR TITLE
Hold en advisory lock for hele slettinga

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/sletterutine/UtdaterteSøknaderJob.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/sletterutine/UtdaterteSøknaderJob.kt
@@ -8,13 +8,11 @@ import java.time.LocalDateTime
 import kotlin.concurrent.fixedRateTimer
 
 internal object UtdaterteSøknaderJob {
-
     private val logger = KotlinLogging.logger {}
     private const val SYV_DAGER = 7
     private val hverTime: Long = 3600000
 
     fun sletterutine(søknadMediator: SøknadMediator) {
-
         if (LeaderElection().isLeader()) {
             fixedRateTimer(
                 name = "Påbegynte søknader vaktmester",


### PR DESCRIPTION
Advisory locks i PostgreSQL er per session og låses automatisk opp når sessionen avsluttes. Når vi lager en egen session for å hente lock så vil den alltid være tilgjengelig.

>While a flag stored in a table could be used for the same purpose, advisory locks are faster, avoid table bloat, and are automatically cleaned up by the server at the end of the session.

Kilde: https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS

Med denne endringen så skal det ikke være nødvendig å bruke leader election.