### PR TITLE
feature/soknad eier validering

### DIFF
--- a/mediator/build.gradle.kts
+++ b/mediator/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("com.zaxxer:HikariCP:5.0.1") //  @todo update HikariCP in service-template
     implementation("org.postgresql:postgresql:42.3.3") //  @todo update postgresql in service-template
     implementation(Database.Kotlinquery)
+    implementation("com.github.ben-manes.caffeine:caffeine:3.1.1")
 
     testImplementation(Ktor2.Server.library("test-host"))
     testImplementation(Ktor2.Client.library("mock"))

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/db/SøknadPostgresRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/db/SøknadPostgresRepository.kt
@@ -48,17 +48,14 @@ class SøknadPostgresRepository(private val dataSource: DataSource) :
                 queryOf(
                     //language=PostgreSQL
                     statement = """
-                    SELECT p.ident
-                    FROM  person_v1 p
-                    INNER JOIN soknad_v1 s
-                    ON p.ident = s.person_ident 
-                    WHERE s.uuid = :uuid
-                    
+                    SELECT person_ident
+                    FROM  soknad_v1
+                    WHERE uuid = :uuid
                     """.trimIndent(),
                     paramMap = mapOf(
                         "uuid" to søknadId
                     )
-                ).map { it.stringOrNull("ident") }.asSingle
+                ).map { it.stringOrNull("person_ident") }.asSingle
             )
         }
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/db/SøknadPostgresRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/db/SøknadPostgresRepository.kt
@@ -42,6 +42,10 @@ import javax.sql.DataSource
 
 class SøknadPostgresRepository(private val dataSource: DataSource) :
     SøknadRepository {
+    override fun hentEier(søknadId: UUID): String? {
+        TODO("Not yet implemented")
+    }
+
     override fun hent(søknadId: UUID, ident: String): Søknad? {
         return using(sessionOf(dataSource)) { session ->
             session.run(
@@ -150,7 +154,8 @@ class SøknadPostgresRepository(private val dataSource: DataSource) :
             dokumentkrav = SøknadDTO.DokumentkravDTO(
                 session.hentDokumentKrav(søknadsId)
             ),
-            sistEndretAvBruker = row.zonedDateTimeOrNull("sist_endret_av_bruker")?.withZoneSameInstant(ZoneId.of("Europe/Oslo")),
+            sistEndretAvBruker = row.zonedDateTimeOrNull("sist_endret_av_bruker")
+                ?.withZoneSameInstant(ZoneId.of("Europe/Oslo")),
             innsendingDTO = session.hentInnsending(søknadsId),
             aktivitetslogg = session.hentAktivitetslogg(søknadsId)
         )

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/db/SøknadPostgresRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/db/SøknadPostgresRepository.kt
@@ -43,7 +43,24 @@ import javax.sql.DataSource
 class SøknadPostgresRepository(private val dataSource: DataSource) :
     SøknadRepository {
     override fun hentEier(søknadId: UUID): String? {
-        TODO("Not yet implemented")
+        return using(sessionOf(dataSource)) { session ->
+            session.run(
+                queryOf(
+                    //language=PostgreSQL
+                    statement = """
+                    SELECT p.ident
+                    FROM  person_v1 p
+                    INNER JOIN soknad_v1 s
+                    ON p.ident = s.person_ident 
+                    WHERE s.uuid = :uuid
+                    
+                    """.trimIndent(),
+                    paramMap = mapOf(
+                        "uuid" to søknadId
+                    )
+                ).map { it.stringOrNull("ident") }.asSingle
+            )
+        }
     }
 
     override fun hent(søknadId: UUID, ident: String): Søknad? {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/SøknadRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/SøknadRepository.kt
@@ -5,6 +5,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 interface SøknadRepository {
+    fun hentEier(søknadId: UUID): String?
     fun hent(søknadId: UUID, ident: String): Søknad?
     fun hentSøknader(ident: String): Set<Søknad>
     fun lagre(søknad: Søknad)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/ferdigstilling/FerdigstillingRoute.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/ferdigstilling/FerdigstillingRoute.kt
@@ -11,13 +11,16 @@ import mu.withLoggingContext
 import no.nav.dagpenger.soknad.SøknadMediator
 import no.nav.dagpenger.soknad.hendelse.SøknadInnsendtHendelse
 import no.nav.dagpenger.soknad.søknadUuid
+import no.nav.dagpenger.soknad.utils.auth.SøknadEierValidator
 import no.nav.dagpenger.soknad.utils.auth.ident
 
 internal fun Route.ferdigstillSøknadRoute(søknadMediator: SøknadMediator) {
+    val validator = SøknadEierValidator(søknadMediator)
     put("/{søknad_uuid}/ferdigstill") {
         val søknadUuid = søknadUuid()
         val ident = call.ident()
         withLoggingContext("søknadid" to søknadUuid.toString()) {
+            validator.valider(søknadUuid, ident)
             val søknadInnsendtHendelse = SøknadInnsendtHendelse(søknadUuid, ident)
             call.receive<JsonNode>().let {
                 søknadMediator.lagreSøknadsTekst(søknadUuid, it.toString())

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/påbegynt/BesvarFaktumRoute.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/påbegynt/BesvarFaktumRoute.kt
@@ -11,6 +11,7 @@ import mu.KotlinLogging
 import mu.withLoggingContext
 import no.nav.dagpenger.soknad.SøknadMediator
 import no.nav.dagpenger.soknad.søknadUuid
+import no.nav.dagpenger.soknad.utils.auth.SøknadEierValidator
 import no.nav.dagpenger.soknad.utils.auth.ident
 import java.time.LocalDateTime
 import kotlin.system.measureTimeMillis
@@ -18,12 +19,14 @@ import kotlin.system.measureTimeMillis
 private val logger = KotlinLogging.logger {}
 
 internal fun Route.besvarFaktumRoute(søknadMediator: SøknadMediator) {
+    val validator = SøknadEierValidator(søknadMediator)
     put("/{søknad_uuid}/faktum/{faktumid}") {
         val tidBrukt = measureTimeMillis {
             val søknadUuid = søknadUuid()
             val ident = call.ident()
             val faktumId = faktumId()
             withLoggingContext("søknadid" to søknadUuid.toString()) {
+                validator.valider(søknadUuid, ident)
                 val input = GyldigSvar(call.receive())
                 logger.info { "Besvarer faktum= $faktumId, type=${input.type} svar=${if (input.type !== "tekst") input.svarAsJson.toString() else "Viser ikke svar på fritekst"}" }
                 val faktumSvar = FaktumSvar(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/påbegynt/NesteSøkerOppgaveRoute.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/påbegynt/NesteSøkerOppgaveRoute.kt
@@ -6,31 +6,27 @@ import io.ktor.server.plugins.NotFoundException
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
-import no.nav.dagpenger.soknad.IkkeTilgangExeption
 import no.nav.dagpenger.soknad.SøknadMediator
 import no.nav.dagpenger.soknad.søknadUuid
+import no.nav.dagpenger.soknad.utils.auth.SøknadEierValidator
 import no.nav.dagpenger.soknad.utils.auth.ident
 import java.time.LocalDateTime
 import java.util.UUID
 
 internal fun Route.nesteSøkeroppgaveRoute(søknadMediator: SøknadMediator) {
+    val validator = SøknadEierValidator(søknadMediator)
     get("/{søknad_uuid}/neste") {
         val id = søknadUuid()
         val ident = call.ident()
+        validator.valider(id, ident)
         val sistLagret = call.parameters["sistLagret"]?.let { LocalDateTime.parse(it) }
-        try {
-            val søkerOppgave: SøkerOppgave = hentNesteSøkerOppgave(søknadMediator, id, sistLagret)
-            if (ident != søkerOppgave.eier()) {
-                throw IkkeTilgangExeption("Ikke tilgang til søknad $id")
-            }
-            call.respond(HttpStatusCode.OK, søkerOppgave.asFrontendformat())
-        } catch (e: NotFoundException) {
-            throw e
-        }
+        val søkerOppgave: SøkerOppgave = hentNesteSøkerOppgave(søknadMediator, id, sistLagret)
+        call.respond(HttpStatusCode.OK, søkerOppgave.asFrontendformat())
     }
 }
 
 private suspend fun hentNesteSøkerOppgave(søknadMediator: SøknadMediator, id: UUID, sistLagret: LocalDateTime?) =
     retryIO(times = 15) {
-        søknadMediator.hent(id, sistLagret) ?: throw NotFoundException("Fant ikke søker_oppgave for søknad med id $id med sistLagret=$sistLagret")
+        søknadMediator.hent(id, sistLagret)
+            ?: throw NotFoundException("Fant ikke søker_oppgave for søknad med id $id med sistLagret=$sistLagret")
     }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/slett/SlettSøknadRoute.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/livssyklus/slett/SlettSøknadRoute.kt
@@ -8,12 +8,15 @@ import io.ktor.server.routing.delete
 import no.nav.dagpenger.soknad.SøknadMediator
 import no.nav.dagpenger.soknad.hendelse.SlettSøknadHendelse
 import no.nav.dagpenger.soknad.søknadUuid
+import no.nav.dagpenger.soknad.utils.auth.SøknadEierValidator
 import no.nav.dagpenger.soknad.utils.auth.ident
 
 internal fun Route.slettSøknadRoute(søknadMediator: SøknadMediator) {
+    val validator = SøknadEierValidator(søknadMediator)
     delete("/{søknad_uuid}") {
         val søknadUuid = søknadUuid()
         val ident = call.ident()
+        validator.valider(søknadUuid, ident)
         val slettSøknadHendelse = SlettSøknadHendelse(søknadUuid, ident)
         søknadMediator.behandle(slettSøknadHendelse)
         call.respond(HttpStatusCode.OK)

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/utils/auth/SøknadEierValidator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/utils/auth/SøknadEierValidator.kt
@@ -1,0 +1,34 @@
+package no.nav.dagpenger.soknad.utils.auth
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import mu.KotlinLogging
+import no.nav.dagpenger.soknad.IkkeTilgangExeption
+import no.nav.dagpenger.soknad.SøknadMediator
+import java.util.UUID
+
+internal class SøknadEierValidator(private val mediator: SøknadMediator) {
+    companion object {
+        private val sikkerLogger = KotlinLogging.logger("tjenestekall")
+        private val cache: Cache<UUID, String> = Caffeine.newBuilder()
+            .maximumSize(10000)
+            .build()
+    }
+
+    fun erEier(søknadId: UUID, forventetEier: String): Boolean {
+        val faktiskEier = requireNotNull(cache.get(søknadId, mediator::hentEier)) {
+            "Fant ikke søknad: $søknadId"
+        }
+        return sjekkEier(faktiskEier, forventetEier)
+    }
+
+    fun valider(søknadId: UUID, forventetEier: String) {
+        if (!erEier(søknadId, forventetEier)) {
+            sikkerLogger.error { "Bruker $forventetEier har ikke tilgang til søknad $søknadId" }
+            throw IkkeTilgangExeption("Ikke eier")
+        }
+    }
+
+    private fun sjekkEier(faktiskEier: String, forventetEier: String) =
+        faktiskEier.equals(forventetEier, true)
+}

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/SøknadApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/SøknadApiTest.kt
@@ -6,6 +6,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -89,6 +90,7 @@ internal class SøknadApiTest {
                 it.behandle(capture(slot))
                 it.lagreSøknadsTekst(testSøknadUuid, any())
             }
+            coEvery { it.hentEier(any()) } returns TestApplication.defaultDummyFodselsnummer
         }
 
         TestApplication.withMockAuthServerAndTestApplication(
@@ -113,7 +115,9 @@ internal class SøknadApiTest {
     @Test
     fun `Kan bare sende json`() {
         val testSøknadUuid = UUID.randomUUID()
-        val søknadMediatorMock = mockk<SøknadMediator>()
+        val søknadMediatorMock = mockk<SøknadMediator>().also {
+            every { it.hentEier(any()) } returns TestApplication.defaultDummyFodselsnummer
+        }
 
         TestApplication.withMockAuthServerAndTestApplication(
             TestApplication.mockedSøknadApi(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/SøknadApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/SøknadApiTest.kt
@@ -197,6 +197,14 @@ internal class SøknadApiTest {
                 assertEquals(HttpStatusCode.Forbidden, it.status)
                 assertEquals("application/json; charset=UTF-8", it.headers["Content-Type"])
             }
+
+            autentisert(
+                "${Configuration.basePath}/soknad/$søknadId",
+                httpMethod = HttpMethod.Delete
+            ).let {
+                assertEquals(HttpStatusCode.Forbidden, it.status)
+                assertEquals("application/json; charset=UTF-8", it.headers["Content-Type"])
+            }
         }
     }
 
@@ -250,11 +258,12 @@ internal class SøknadApiTest {
 
     @Test
     fun `Skal kunne slette påbegynt søknad`() {
-        val søknadUuid = UUID.fromString("d172a832-4f52-4e1f-ab5f-8be8348d9280")
+        val søknadUuid = UUID.randomUUID()
         val mockSøknadMediator = mockk<SøknadMediator>().also {
             justRun {
                 it.behandle(any<SlettSøknadHendelse>())
             }
+            coEvery { it.hentEier(søknadUuid) } returns defaultDummyFodselsnummer
         }
 
         TestApplication.withMockAuthServerAndTestApplication(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/SøknadMediatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/SøknadMediatorTest.kt
@@ -42,6 +42,10 @@ internal class SøknadMediatorTest {
     private object TestSøknadRepository : SøknadRepository {
 
         private val søknader = mutableListOf<Søknad>()
+        override fun hentEier(søknadId: UUID): String? {
+            TODO("Not yet implemented")
+        }
+
         override fun hent(søknadId: UUID, ident: String): Søknad? {
             return søknader.find { it.søknadUUID() == søknadId }
         }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/db/SøknadPostgresRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/db/SøknadPostgresRepositoryTest.kt
@@ -71,6 +71,18 @@ internal class SøknadPostgresRepositoryTest {
     )
 
     @Test
+    fun `Henting av eier til søknad`() {
+        withMigratedDb {
+            SøknadPostgresRepository(PostgresDataSourceBuilder.dataSource).let { repository ->
+                repository.lagre(søknad)
+
+                assertEquals(ident, repository.hentEier(søknad.søknadUUID()))
+                assertNull(repository.hentEier(UUID.randomUUID()))
+            }
+        }
+    }
+
+    @Test
     fun `Lagre og hente søknad med dokument, dokumentkrav, innsending og aktivitetslogg`() {
         val søknad = Søknad.rehydrer(
             søknadId = søknadId,

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/utils/auth/SøknadEierValidatorTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/utils/auth/SøknadEierValidatorTest.kt
@@ -1,0 +1,66 @@
+package no.nav.dagpenger.soknad.utils.auth
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.dagpenger.soknad.IkkeTilgangExeption
+import no.nav.dagpenger.soknad.SøknadMediator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+internal class SøknadEierValidatorTest {
+    private val søknadId1 = UUID.randomUUID()
+    private val søknadId2 = UUID.randomUUID()
+    private val ukjentSøknadId = UUID.randomUUID()
+    private val eier1 = "eier1"
+    private val eier2 = "eier2"
+
+    private val søknadMediatorMock: SøknadMediator = mockk<SøknadMediator>().also {
+        every { it.hentEier(søknadId1) } returns eier1
+        every { it.hentEier(søknadId2) } returns eier2
+        every { it.hentEier(ukjentSøknadId) } returns null
+    }
+
+    @Test
+    fun `rikig eier gir ingen validerings feil`() {
+        SøknadEierValidator(søknadMediatorMock).let { validator ->
+            assertDoesNotThrow {
+                validator.valider(søknadId1, eier1)
+            }
+        }
+    }
+
+    @Test
+    fun `feil eier gir validerings feil`() {
+        SøknadEierValidator(søknadMediatorMock).let { validator ->
+            assertThrows<IkkeTilgangExeption> {
+                validator.valider(søknadId2, eier1)
+            }
+        }
+    }
+
+    @Test
+    fun `Ingen eier for søknad gir validerings feil`() {
+        SøknadEierValidator(søknadMediatorMock).let { validator ->
+            assertThrows<IllegalArgumentException> {
+                validator.valider(ukjentSøknadId, eier1)
+            }
+        }
+    }
+
+    @Test
+    fun `caching`() {
+        repeat(5) { SøknadEierValidator(søknadMediatorMock).valider(søknadId1, eier1) }
+        verify(exactly = 1) { søknadMediatorMock.hentEier(søknadId1) }
+
+        repeat(5) {
+            try {
+                SøknadEierValidator(søknadMediatorMock).valider(ukjentSøknadId, eier1)
+            } catch (_: Exception) {
+            }
+        }
+        verify(exactly = 5) { søknadMediatorMock.hentEier(ukjentSøknadId) }
+    }
+}


### PR DESCRIPTION
Følgende ruter sjekket:

`

* startsøknadroute - /arbeid/dagpenger/soknadapi - post ingen validering vi lager alltid en  ny søknad.
* påbegyntsøknadroute - /arbeid/dagpenger/soknadapi/paabegynt - get ingen validering, basert på fnr fra jwt
* ferdigstillsøknadroute - /arbeid/dagpenger/soknadapi/paabegynt/{søknad_uuid}/ferdigstill - post - trenger validering
* nestesøkeroppgaveroute - /arbeid/dagpenger/soknadapi/paabegynt/{søknad_uuid}/neste -  get - trenger validering
* besvarfaktumroute -  /arbeid/dagpenger/soknadapi/{søknad_uuid}/faktum/{faktumid} - put - trenger validering
* slettsøknadroute -  /arbeid/dagpenger/soknadapi/{søknad_uuid} - delete  - trenger validering
* dokumentasjonroute  -  /arbeid/dagpenger/soknadapi/{søknad_uuid}/dokumentasjonskrav  - validering på alle endepunkter
* ferdigstiltsøknadroute /arbeid/dagpenger/soknadapi/{søknad_uuid}/ferdigstilt - azuread endpunkt. free for all.

`
