### PR TITLE
feature/hent dokumentasjons krav med AzureAd token

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/dokumentasjonskrav/DokumentasjonKravApi.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/dokumentasjonskrav/DokumentasjonKravApi.kt
@@ -30,6 +30,7 @@ import no.nav.dagpenger.soknad.hendelse.SlettFil
 import no.nav.dagpenger.soknad.søknadUuid
 import no.nav.dagpenger.soknad.utils.auth.SøknadEierValidator
 import no.nav.dagpenger.soknad.utils.auth.ident
+import no.nav.dagpenger.soknad.utils.auth.optionalIdent
 import no.nav.dagpenger.soknad.utils.serder.objectMapper
 import java.time.ZonedDateTime
 import java.util.UUID
@@ -44,14 +45,9 @@ internal fun Route.dokumentasjonkravRoute(søknadMediator: SøknadMediator) {
             get {
                 val søknadUuid = søknadUuid()
                 withLoggingContext("søknadid" to søknadUuid.toString()) {
-                    // todo ikke baser logikk på exceptions
-                    kotlin.runCatching { call.ident() }
-                        .onFailure {
-                            // todo Antar at det er gyldig azureAd token.  Valider mot azp?
-                        }
-                        .onSuccess { ident ->
-                            validator.valider(søknadUuid, ident)
-                        }
+                    call.optionalIdent()?.let { ident ->
+                        validator.valider(søknadUuid, ident)
+                    }
                     val søknad =
                         søknadMediator.hent(søknadUuid) ?: throw NotFoundException("Dokumentasjon ikke funnet")
                     call.respond(ApiDokumentkravResponse(søknad))

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/utils/auth/Jwt.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/utils/auth/Jwt.kt
@@ -15,12 +15,17 @@ internal fun validator(jwtCredential: JWTCredential): Principal {
     return JWTPrincipal(jwtCredential.payload)
 }
 
-internal fun ApplicationCall.ident(): String = requireNotNull(this.authentication.principal<JWTPrincipal>()) { "Ikke autentisert" }.fnr
+internal fun ApplicationCall.ident(): String =
+    requireNotNull(this.authentication.principal<JWTPrincipal>()) { "Ikke autentisert" }.fnr
 
 internal val JWTPrincipal.fnr get(): String = requirePid(this)
 
-private fun requirePid(credential: JWTPayloadHolder): String = requireNotNull(credential.payload.claims["pid"]?.asString()) { "Token må inneholde fødselsnummer for personen i claim 'pid'" }
+private fun requirePid(credential: JWTPayloadHolder): String =
+    requireNotNull(credential.payload.claims["pid"]?.asString()) { "Token må inneholde fødselsnummer for personen i claim 'pid'" }
 
 internal fun ApplicationRequest.jwt(): String = this.parseAuthorizationHeader().let { authHeader ->
     (authHeader as? HttpAuthHeader.Single)?.blob ?: throw IllegalArgumentException("JWT not found")
 }
+
+internal fun ApplicationCall.optionalIdent(): String? =
+    requireNotNull(this.authentication.principal<JWTPrincipal>()).payload.claims["pid"]?.asString()

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/SøknadApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/SøknadApiTest.kt
@@ -70,7 +70,7 @@ internal class SøknadApiTest {
 
             autentisert(
                 endepunkt = "${Configuration.basePath}/soknad",
-                token = TestApplication.getToken("12345678910"),
+                token = TestApplication.getTokenXToken("12345678910"),
                 httpMethod = HttpMethod.Post
             ).apply {
                 assertEquals(HttpStatusCode.OK, this.status)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/TestApplication.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/TestApplication.kt
@@ -20,8 +20,9 @@ import no.nav.dagpenger.soknad.personalia.personaliaRouteBuilder
 import no.nav.security.mock.oauth2.MockOAuth2Server
 
 object TestApplication {
-    private const val ISSUER_ID = "default"
-    private const val CLIENT_ID = "default"
+    private const val TOKENX_ISSUER_ID = "tokenx"
+    private const val CLIENT_ID = "dp-soknad"
+    private const val AZURE_ISSUER_ID = "azuread"
     const val defaultDummyFodselsnummer = "12345"
 
     private val mockOAuth2Server: MockOAuth2Server by lazy {
@@ -30,16 +31,25 @@ object TestApplication {
         }
     }
 
-    private val testOAuthToken: String by lazy {
+    internal val testTokenXToken: String by lazy {
         mockOAuth2Server.issueToken(
-            issuerId = ISSUER_ID,
+            issuerId = TOKENX_ISSUER_ID,
+            audience = CLIENT_ID,
             claims = mapOf("pid" to defaultDummyFodselsnummer)
         ).serialize()
     }
 
-    internal fun getToken(pid: String): String {
+    internal val azureAdToken: String by lazy {
+        mockOAuth2Server.issueToken(
+            issuerId = AZURE_ISSUER_ID,
+            audience = CLIENT_ID,
+        ).serialize()
+    }
+
+    internal fun getTokenXToken(pid: String): String {
         return mockOAuth2Server.issueToken(
-            issuerId = ISSUER_ID,
+            issuerId = TOKENX_ISSUER_ID,
+            audience = CLIENT_ID,
             claims = mapOf("pid" to pid)
         ).serialize()
     }
@@ -66,9 +76,9 @@ object TestApplication {
         test: suspend ApplicationTestBuilder.() -> Unit
     ) {
         System.setProperty("token-x.client-id", CLIENT_ID)
-        System.setProperty("token-x.well-known-url", "${mockOAuth2Server.wellKnownUrl(ISSUER_ID)}")
+        System.setProperty("token-x.well-known-url", "${mockOAuth2Server.wellKnownUrl(TOKENX_ISSUER_ID)}")
         System.setProperty("azure-app.client-id", CLIENT_ID)
-        System.setProperty("azure-app.well-known-url", "${mockOAuth2Server.wellKnownUrl(ISSUER_ID)}")
+        System.setProperty("azure-app.well-known-url", "${mockOAuth2Server.wellKnownUrl(AZURE_ISSUER_ID)}")
 
         return testApplication {
             application(moduleFunction)
@@ -76,13 +86,13 @@ object TestApplication {
         }
     }
 
-    internal fun HttpRequestBuilder.autentisert(token: String = testOAuthToken) {
+    internal fun HttpRequestBuilder.autentisert(token: String = testTokenXToken) {
         this.header(HttpHeaders.Authorization, "Bearer $token")
     }
 
     internal suspend fun ApplicationTestBuilder.autentisert(
         endepunkt: String,
-        token: String = testOAuthToken,
+        token: String = testTokenXToken,
         httpMethod: HttpMethod = HttpMethod.Get,
         body: String? = null,
     ): HttpResponse {

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/livssyklus/ferdigstilling/FerdigstiltSøknadApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/livssyklus/ferdigstilling/FerdigstiltSøknadApiTest.kt
@@ -2,6 +2,7 @@ package no.nav.dagpenger.soknad.livssyklus.ferdigstilling
 
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.plugins.NotFoundException
@@ -31,6 +32,14 @@ internal class FerdigstiltSøknadApiTest {
                 HttpStatusCode.Unauthorized,
                 client.get("${Configuration.basePath}/${UUID.randomUUID()}/ferdigstilt/fakta").status
             )
+            assertEquals(
+                HttpStatusCode.Unauthorized,
+                autentisert(
+                    endepunkt = "${Configuration.basePath}/${UUID.randomUUID()}/ferdigstilt/fakta",
+                    token = TestApplication.testTokenXToken,
+                    httpMethod = HttpMethod.Get
+                ).status
+            )
         }
     }
 
@@ -40,12 +49,14 @@ internal class FerdigstiltSøknadApiTest {
             assertEquals(
                 HttpStatusCode.OK,
                 autentisert(
+                    token = TestApplication.azureAdToken,
                     endepunkt = "${Configuration.basePath}/${UUID.randomUUID()}/ferdigstilt/tekst"
                 ).status
             )
             assertEquals(
                 HttpStatusCode.OK,
                 autentisert(
+                    token = TestApplication.azureAdToken,
                     endepunkt = "${Configuration.basePath}/${UUID.randomUUID()}/ferdigstilt/tekst"
                 ).status
             )

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/livssyklus/påbegynt/PåbegyntSøknadApiTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/livssyklus/påbegynt/PåbegyntSøknadApiTest.kt
@@ -35,7 +35,7 @@ class PåbegyntSøknadApiTest {
         ) {
             autentisert(
                 endepunkt = "${Configuration.basePath}/soknad/paabegynt",
-                token = TestApplication.getToken("harsoknad"),
+                token = TestApplication.getTokenXToken("harsoknad"),
                 httpMethod = HttpMethod.Get,
             ).apply {
                 val expectedJson = """{"uuid":"258b2f1b-bdda-4bed-974c-c4ddb206e4f4","startDato":"2021-10-03","språk":"NO"}"""
@@ -56,7 +56,7 @@ class PåbegyntSøknadApiTest {
         ) {
             autentisert(
                 endepunkt = "${Configuration.basePath}/soknad/paabegynt",
-                token = TestApplication.getToken("ingensoknad"),
+                token = TestApplication.getTokenXToken("ingensoknad"),
                 httpMethod = HttpMethod.Get,
             ).apply {
                 assertEquals(HttpStatusCode.NotFound, this.status)


### PR DESCRIPTION
Veldig WIP, men godt nok(I teorien for å hente ut dokumentasjonskrav), slik at det ikke blokker fremgang. 

- Bruke to oauth providers i tester
- Very WIP: AzureAd på dokumentasjons krav
