### PR TITLE
Splittet opp NyInnsendingBehovMottak i to mottak

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,7 +42,7 @@ jobs:
 
   deploy-dev:
     needs: [ build ]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/splitteOppNyInnsendingBehovMottakITo'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -54,16 +54,16 @@ jobs:
           VARS: mediator/nais/dev/vars.yaml
           PRINT_PAYLOAD: true
 
-  deploy-prod:
-    needs: [ build ]
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: mediator/nais/nais.yaml
-          VARS: mediator/nais/prod/vars.yaml
-          PRINT_PAYLOAD: true
+#  deploy-prod:
+#    needs: [ build ]
+#    if: github.ref == 'refs/heads/main'
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: nais/deploy/actions/deploy@v1
+#        env:
+#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+#          CLUSTER: prod-gcp
+#          RESOURCE: mediator/nais/nais.yaml
+#          VARS: mediator/nais/prod/vars.yaml
+#          PRINT_PAYLOAD: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,7 +42,7 @@ jobs:
 
   deploy-dev:
     needs: [ build ]
-    if: github.ref == 'refs/heads/splitteOppNyInnsendingBehovMottakITo'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,16 +54,16 @@ jobs:
           VARS: mediator/nais/dev/vars.yaml
           PRINT_PAYLOAD: true
 
-#  deploy-prod:
-#    needs: [ build ]
-#    if: github.ref == 'refs/heads/main'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: nais/deploy/actions/deploy@v1
-#        env:
-#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-#          CLUSTER: prod-gcp
-#          RESOURCE: mediator/nais/nais.yaml
-#          VARS: mediator/nais/prod/vars.yaml
-#          PRINT_PAYLOAD: true
+  deploy-prod:
+    needs: [ build ]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: mediator/nais/nais.yaml
+          VARS: mediator/nais/prod/vars.yaml
+          PRINT_PAYLOAD: true

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/ApplicationBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/ApplicationBuilder.kt
@@ -9,6 +9,7 @@ import no.nav.dagpenger.soknad.innsending.InnsendingMediator
 import no.nav.dagpenger.soknad.innsending.InnsendingPostgresRepository
 import no.nav.dagpenger.soknad.innsending.tjenester.ArkiverbarSøknadMottattHendelseMottak
 import no.nav.dagpenger.soknad.innsending.tjenester.JournalførtMottak
+import no.nav.dagpenger.soknad.innsending.tjenester.NyEttersendingBehovMottak
 import no.nav.dagpenger.soknad.innsending.tjenester.NyInnsendingBehovMottak
 import no.nav.dagpenger.soknad.innsending.tjenester.NyJournalpostMottak
 import no.nav.dagpenger.soknad.innsending.tjenester.SkjemakodeMottak
@@ -89,6 +90,7 @@ internal class ApplicationBuilder(config: Map<String, String>) : RapidsConnectio
         JournalførtMottak(rapidsConnection, it)
         SkjemakodeMottak(rapidsConnection, it)
         NyInnsendingBehovMottak(rapidsConnection, it)
+        NyEttersendingBehovMottak(rapidsConnection, it)
     }
 
     init {

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/MeldingOmInnsending.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/MeldingOmInnsending.kt
@@ -2,7 +2,6 @@ package no.nav.dagpenger.soknad.innsending.meldinger
 
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.Innsending
-import no.nav.dagpenger.soknad.hendelse.Hendelse
 import no.nav.dagpenger.soknad.utils.asUUID
 import no.nav.dagpenger.soknad.utils.asZonedDateTime
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -15,8 +14,8 @@ abstract class MeldingOmInnsending(packet: JsonMessage) {
     protected val dokumentkrav: List<Innsending.Dokument> = packet.dokumentkrav()
     protected val ident = packet["ident"].asText()
 
-    abstract val innsending: Innsending
-    abstract fun hendelse(): Hendelse
+    protected abstract val innsending: Innsending
+    fun hendelse(): NyInnsendingHendelse = NyInnsendingHendelse(innsending, ident)
 
     private fun JsonMessage.dokumentkrav(): List<Innsending.Dokument> {
         return this["dokumentkrav"].map { jsonNode ->

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/MeldingOmInnsending.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/MeldingOmInnsending.kt
@@ -1,0 +1,51 @@
+package no.nav.dagpenger.soknad.innsending.meldinger
+
+import com.fasterxml.jackson.databind.JsonNode
+import no.nav.dagpenger.soknad.Innsending
+import no.nav.dagpenger.soknad.hendelse.Hendelse
+import no.nav.dagpenger.soknad.utils.asUUID
+import no.nav.dagpenger.soknad.utils.asZonedDateTime
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.isMissingOrNull
+import java.time.ZonedDateTime
+
+abstract class MeldingOmInnsending(packet: JsonMessage) {
+    protected val søknadId = packet["søknad_uuid"].asUUID()
+    protected val innsendt: ZonedDateTime = packet["innsendtTidspunkt"].asZonedDateTime()
+    protected val dokumentkrav: List<Innsending.Dokument> = packet.dokumentkrav()
+    protected val ident = packet["ident"].asText()
+
+    abstract val innsending: Innsending
+    abstract fun hendelse(): Hendelse
+
+    private fun JsonMessage.dokumentkrav(): List<Innsending.Dokument> {
+        return this["dokumentkrav"].map { jsonNode ->
+            Innsending.Dokument(
+                uuid = jsonNode["uuid"].asUUID(),
+                kravId = jsonNode["kravId"].asNullableText(),
+                skjemakode = jsonNode["skjemakode"].asNullableText(),
+                varianter = jsonNode.varianter()
+            )
+        }
+    }
+
+    private fun JsonNode.varianter(): List<Innsending.Dokument.Dokumentvariant> {
+        return this["varianter"].map { jsonNode ->
+            Innsending.Dokument.Dokumentvariant(
+                uuid = jsonNode["uuid"].asUUID(),
+                filnavn = jsonNode["filnavn"].asText(),
+                urn = jsonNode["urn"].asText(),
+                variant = jsonNode["variant"].asText(),
+                type = jsonNode["type"].asText()
+            )
+        }
+    }
+
+    private fun JsonNode.asNullableText(): String? {
+        return if (this.isMissingOrNull()) {
+            null
+        } else {
+            this.asText()
+        }
+    }
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyEttersendingMelding.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyEttersendingMelding.kt
@@ -1,17 +1,9 @@
 package no.nav.dagpenger.soknad.innsending.meldinger
 
 import no.nav.dagpenger.soknad.Innsending
-import no.nav.dagpenger.soknad.utils.asUUID
-import no.nav.dagpenger.soknad.utils.asZonedDateTime
 import no.nav.helse.rapids_rivers.JsonMessage
-import java.time.ZonedDateTime
 
-class NyEttersendingMelding(packet: JsonMessage) {
-    private val søknadId = packet["søknad_uuid"].asUUID()
-    private val innsendt: ZonedDateTime = packet["innsendtTidspunkt"].asZonedDateTime()
-    private val dokumentkrav: List<Innsending.Dokument> = packet.dokumentkrav()
-    private val ident = packet["ident"].asText()
-    private val innsending = Innsending.ettersending(innsendt, ident, søknadId, dokumentkrav)
-
-    fun hendelse(): NyInnsendingHendelse = NyInnsendingHendelse(innsending, ident)
+class NyEttersendingMelding(packet: JsonMessage) : MeldingOmInnsending(packet) {
+    override val innsending = Innsending.ettersending(innsendt, ident, søknadId, dokumentkrav)
+    override fun hendelse(): NyInnsendingHendelse = NyInnsendingHendelse(innsending, ident)
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyEttersendingMelding.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyEttersendingMelding.kt
@@ -5,5 +5,4 @@ import no.nav.helse.rapids_rivers.JsonMessage
 
 class NyEttersendingMelding(packet: JsonMessage) : MeldingOmInnsending(packet) {
     override val innsending = Innsending.ettersending(innsendt, ident, søknadId, dokumentkrav)
-    override fun hendelse(): NyInnsendingHendelse = NyInnsendingHendelse(innsending, ident)
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyEttersendingMelding.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyEttersendingMelding.kt
@@ -1,0 +1,17 @@
+package no.nav.dagpenger.soknad.innsending.meldinger
+
+import no.nav.dagpenger.soknad.Innsending
+import no.nav.dagpenger.soknad.utils.asUUID
+import no.nav.dagpenger.soknad.utils.asZonedDateTime
+import no.nav.helse.rapids_rivers.JsonMessage
+import java.time.ZonedDateTime
+
+class NyEttersendingMelding(packet: JsonMessage) {
+    private val søknadId = packet["søknad_uuid"].asUUID()
+    private val innsendt: ZonedDateTime = packet["innsendtTidspunkt"].asZonedDateTime()
+    private val dokumentkrav: List<Innsending.Dokument> = packet.dokumentkrav()
+    private val ident = packet["ident"].asText()
+    private val innsending = Innsending.ettersending(innsendt, ident, søknadId, dokumentkrav)
+
+    fun hendelse(): NyInnsendingHendelse = NyInnsendingHendelse(innsending, ident)
+}

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingMelding.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingMelding.kt
@@ -5,5 +5,4 @@ import no.nav.helse.rapids_rivers.JsonMessage
 
 class NyInnsendingMelding(packet: JsonMessage) : MeldingOmInnsending(packet) {
     override val innsending = Innsending.ny(innsendt, ident, søknadId, dokumentkrav)
-    override fun hendelse(): NyInnsendingHendelse = NyInnsendingHendelse(innsending, ident)
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingMelding.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingMelding.kt
@@ -1,11 +1,7 @@
 package no.nav.dagpenger.soknad.innsending.meldinger
 
 import com.fasterxml.jackson.databind.JsonNode
-import no.nav.dagpenger.soknad.Aktivitetslogg.Aktivitet.Behov.Behovtype.NyEttersending
-import no.nav.dagpenger.soknad.Aktivitetslogg.Aktivitet.Behov.Behovtype.NyInnsending
 import no.nav.dagpenger.soknad.Innsending
-import no.nav.dagpenger.soknad.Innsending.InnsendingType.ETTERSENDING_TIL_DIALOG
-import no.nav.dagpenger.soknad.Innsending.InnsendingType.NY_DIALOG
 import no.nav.dagpenger.soknad.utils.asUUID
 import no.nav.dagpenger.soknad.utils.asZonedDateTime
 import no.nav.helse.rapids_rivers.JsonMessage
@@ -17,54 +13,38 @@ class NyInnsendingMelding(packet: JsonMessage) {
     private val innsendt: ZonedDateTime = packet["innsendtTidspunkt"].asZonedDateTime()
     private val dokumentkrav: List<Innsending.Dokument> = packet.dokumentkrav()
     private val ident = packet["ident"].asText()
-    private val innsending = when (packet.innsendingType()) {
-        NY_DIALOG -> Innsending.ny(innsendt, ident, søknadId, dokumentkrav)
-        ETTERSENDING_TIL_DIALOG -> Innsending.ettersending(innsendt, ident, søknadId, dokumentkrav)
-    }
+    private val innsending = Innsending.ny(innsendt, ident, søknadId, dokumentkrav)
 
     fun hendelse(): NyInnsendingHendelse = NyInnsendingHendelse(innsending, ident)
+}
 
-    companion object {
-        fun JsonMessage.behov() = this["@behov"].single().asText()
-        fun JsonMessage.innsendingType(): Innsending.InnsendingType {
-            return when (val behovtype = this.behov()) {
-                NyInnsending.name -> NY_DIALOG
-                NyEttersending.name -> ETTERSENDING_TIL_DIALOG
-                else -> {
-                    throw IllegalArgumentException("Ukjent behovtype: $behovtype")
-                }
-            }
-        }
+fun JsonMessage.dokumentkrav(): List<Innsending.Dokument> {
+    return this["dokumentkrav"].map { jsonNode ->
+        Innsending.Dokument(
+            uuid = jsonNode["uuid"].asUUID(),
+            kravId = jsonNode["kravId"].asNullableText(),
+            skjemakode = jsonNode["skjemakode"].asNullableText(),
+            varianter = jsonNode.varianter()
+        )
+    }
+}
 
-        fun JsonMessage.dokumentkrav(): List<Innsending.Dokument> {
-            return this["dokumentkrav"].map { jsonNode ->
-                Innsending.Dokument(
-                    uuid = jsonNode["uuid"].asUUID(),
-                    kravId = jsonNode["kravId"].asNullableText(),
-                    skjemakode = jsonNode["skjemakode"].asNullableText(),
-                    varianter = jsonNode.varianter()
-                )
-            }
-        }
+fun JsonNode.varianter(): List<Innsending.Dokument.Dokumentvariant> {
+    return this["varianter"].map { jsonNode ->
+        Innsending.Dokument.Dokumentvariant(
+            uuid = jsonNode["uuid"].asUUID(),
+            filnavn = jsonNode["filnavn"].asText(),
+            urn = jsonNode["urn"].asText(),
+            variant = jsonNode["variant"].asText(),
+            type = jsonNode["type"].asText()
+        )
+    }
+}
 
-        fun JsonNode.varianter(): List<Innsending.Dokument.Dokumentvariant> {
-            return this["varianter"].map { jsonNode ->
-                Innsending.Dokument.Dokumentvariant(
-                    uuid = jsonNode["uuid"].asUUID(),
-                    filnavn = jsonNode["filnavn"].asText(),
-                    urn = jsonNode["urn"].asText(),
-                    variant = jsonNode["variant"].asText(),
-                    type = jsonNode["type"].asText()
-                )
-            }
-        }
-
-        fun JsonNode.asNullableText(): String? {
-            return if (this.isMissingOrNull()) {
-                null
-            } else {
-                this.asText()
-            }
-        }
+fun JsonNode.asNullableText(): String? {
+    return if (this.isMissingOrNull()) {
+        null
+    } else {
+        this.asText()
     }
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingMelding.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingMelding.kt
@@ -1,50 +1,9 @@
 package no.nav.dagpenger.soknad.innsending.meldinger
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.nav.dagpenger.soknad.Innsending
-import no.nav.dagpenger.soknad.utils.asUUID
-import no.nav.dagpenger.soknad.utils.asZonedDateTime
 import no.nav.helse.rapids_rivers.JsonMessage
-import no.nav.helse.rapids_rivers.isMissingOrNull
-import java.time.ZonedDateTime
 
-class NyInnsendingMelding(packet: JsonMessage) {
-    private val søknadId = packet["søknad_uuid"].asUUID()
-    private val innsendt: ZonedDateTime = packet["innsendtTidspunkt"].asZonedDateTime()
-    private val dokumentkrav: List<Innsending.Dokument> = packet.dokumentkrav()
-    private val ident = packet["ident"].asText()
-    private val innsending = Innsending.ny(innsendt, ident, søknadId, dokumentkrav)
-
-    fun hendelse(): NyInnsendingHendelse = NyInnsendingHendelse(innsending, ident)
-}
-
-fun JsonMessage.dokumentkrav(): List<Innsending.Dokument> {
-    return this["dokumentkrav"].map { jsonNode ->
-        Innsending.Dokument(
-            uuid = jsonNode["uuid"].asUUID(),
-            kravId = jsonNode["kravId"].asNullableText(),
-            skjemakode = jsonNode["skjemakode"].asNullableText(),
-            varianter = jsonNode.varianter()
-        )
-    }
-}
-
-fun JsonNode.varianter(): List<Innsending.Dokument.Dokumentvariant> {
-    return this["varianter"].map { jsonNode ->
-        Innsending.Dokument.Dokumentvariant(
-            uuid = jsonNode["uuid"].asUUID(),
-            filnavn = jsonNode["filnavn"].asText(),
-            urn = jsonNode["urn"].asText(),
-            variant = jsonNode["variant"].asText(),
-            type = jsonNode["type"].asText()
-        )
-    }
-}
-
-fun JsonNode.asNullableText(): String? {
-    return if (this.isMissingOrNull()) {
-        null
-    } else {
-        this.asText()
-    }
+class NyInnsendingMelding(packet: JsonMessage) : MeldingOmInnsending(packet) {
+    override val innsending = Innsending.ny(innsendt, ident, søknadId, dokumentkrav)
+    override fun hendelse(): NyInnsendingHendelse = NyInnsendingHendelse(innsending, ident)
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/tjenester/NyEttersendingBehovMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/soknad/innsending/tjenester/NyEttersendingBehovMottak.kt
@@ -2,16 +2,16 @@ package no.nav.dagpenger.soknad.innsending.tjenester
 
 import mu.KotlinLogging
 import mu.withLoggingContext
-import no.nav.dagpenger.soknad.Aktivitetslogg.Aktivitet.Behov.Behovtype.NyInnsending
+import no.nav.dagpenger.soknad.Aktivitetslogg.Aktivitet.Behov.Behovtype.NyEttersending
 import no.nav.dagpenger.soknad.innsending.InnsendingMediator
-import no.nav.dagpenger.soknad.innsending.meldinger.NyInnsendingMelding
+import no.nav.dagpenger.soknad.innsending.meldinger.NyEttersendingMelding
 import no.nav.dagpenger.soknad.utils.asUUID
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 
-internal class NyInnsendingBehovMottak(rapidsConnection: RapidsConnection, private val mediator: InnsendingMediator) :
+internal class NyEttersendingBehovMottak(rapidsConnection: RapidsConnection, private val mediator: InnsendingMediator) :
     River.PacketListener {
     companion object {
         private val logger = KotlinLogging.logger {}
@@ -20,7 +20,7 @@ internal class NyInnsendingBehovMottak(rapidsConnection: RapidsConnection, priva
     init {
         River(rapidsConnection).apply {
             validate { it.demandValue("@event_name", "behov") }
-            validate { it.demandAllOrAny("@behov", listOf(NyInnsending.name)) }
+            validate { it.demandAllOrAny("@behov", listOf(NyEttersending.name)) }
             validate { it.requireKey("søknad_uuid", "ident", "innsendtTidspunkt") }
             validate { it.interestedIn("dokumentkrav") }
             validate { it.rejectKey("@løsning") }
@@ -33,10 +33,10 @@ internal class NyInnsendingBehovMottak(rapidsConnection: RapidsConnection, priva
         withLoggingContext(
             "søknadId" to søknadId.toString(),
         ) {
-            val behov = NyInnsending.name
+            val behov = NyEttersending.name
             logger.info { "Mottatt behov for ny innsending av type: $behov" }
 
-            val hendelse = NyInnsendingMelding(packet).hendelse()
+            val hendelse = NyEttersendingMelding(packet).hendelse()
             mediator.behandle(hendelse)
 
             packet["@løsning"] = mapOf(

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingBehovMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingBehovMottakTest.kt
@@ -32,11 +32,19 @@ internal class NyInnsendingBehovMottakTest {
         fun testFixtures(): List<TestFixture> {
             return listOf(
                 TestFixture(
-                    behov = Behovtype.NyInnsending,
+                    behov = listOf(Behovtype.NyInnsending),
                     innsendingType = NY_DIALOG
                 ),
                 TestFixture(
-                    behov = Behovtype.NyEttersending,
+                    behov = listOf(Behovtype.NyEttersending),
+                    innsendingType = ETTERSENDING_TIL_DIALOG
+                ),
+                TestFixture(
+                    behov = listOf(Behovtype.NyInnsending, Behovtype.NySøknad),
+                    innsendingType = NY_DIALOG
+                ),
+                TestFixture(
+                    behov = listOf(Behovtype.NyEttersending, Behovtype.InnsendingMetadata),
                     innsendingType = ETTERSENDING_TIL_DIALOG
                 )
             )
@@ -82,7 +90,7 @@ internal class NyInnsendingBehovMottakTest {
             testRapid.inspektør.field(
                 index = 0,
                 field = "@løsning"
-            ).get(testFixture.behov.name)
+            ).get(testFixture.behov[0].name)
         )
     }
 
@@ -139,7 +147,7 @@ internal class NyInnsendingBehovMottakTest {
     private fun lagTestJson(fixture: TestFixture): String {
         val map = mutableMapOf(
             "@event_name" to "behov",
-            "@behov" to listOf(fixture.behov),
+            "@behov" to fixture.behov,
             "søknad_uuid" to fixture.søknadId,
             "innsendtTidspunkt" to fixture.innsendtTidspunkt,
             "dokumentkrav" to fixture.dokumenter,
@@ -217,7 +225,7 @@ internal class NyInnsendingBehovMottakTest {
         ),
         val ident: String = "1234",
         val løsning: Map<String, Any>? = null,
-        val behov: Behovtype,
+        val behov: List<Behovtype>,
         val innsendingType: InnsendingType,
     )
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingBehovMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/soknad/innsending/meldinger/NyInnsendingBehovMottakTest.kt
@@ -13,6 +13,7 @@ import no.nav.dagpenger.soknad.Innsending.InnsendingType.ETTERSENDING_TIL_DIALOG
 import no.nav.dagpenger.soknad.Innsending.InnsendingType.NY_DIALOG
 import no.nav.dagpenger.soknad.InnsendingVisitor
 import no.nav.dagpenger.soknad.innsending.InnsendingMediator
+import no.nav.dagpenger.soknad.innsending.tjenester.NyEttersendingBehovMottak
 import no.nav.dagpenger.soknad.innsending.tjenester.NyInnsendingBehovMottak
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
@@ -58,6 +59,10 @@ internal class NyInnsendingBehovMottakTest {
             rapidsConnection = testRapid,
             mediator = mediator
         )
+        NyEttersendingBehovMottak(
+            rapidsConnection = testRapid,
+            mediator = mediator
+        )
 
         testRapid.sendTestMessage(
             lagTestJson(fixture = testFixture)
@@ -88,6 +93,11 @@ internal class NyInnsendingBehovMottakTest {
             rapidsConnection = testRapid,
             mediator = mediator
         )
+        NyEttersendingBehovMottak(
+            rapidsConnection = testRapid,
+            mediator = mediator
+        )
+
         testRapid.sendTestMessage(
             lagTestJson(
                 testFixture.copy(
@@ -107,6 +117,10 @@ internal class NyInnsendingBehovMottakTest {
     @MethodSource("testFixtures")
     fun `Skal håndtere NyInnsending uten dokumenter`(testFixture: TestFixture) {
         NyInnsendingBehovMottak(
+            rapidsConnection = testRapid,
+            mediator = mediator
+        )
+        NyEttersendingBehovMottak(
             rapidsConnection = testRapid,
             mediator = mediator
         )


### PR DESCRIPTION
Slik at det er et mottak per behovtype som det gamle mottaket støttet. Da kunne kode som skilte mellom disse to behovtypene fjernes.

Dette skal også gjøre det mulig å bruke grupperte behov, sammen med eventene som mottakene støtter.

Har gjort endringene gradvis, så se gjerne på hver enkelt commit for å se at logikken i enhetstestene egentlig ikke er endret.