### PR TITLE
Erstatter azure-token-generator med wonderwaller-idporten

### DIFF
--- a/mediator/nais/nais.yaml
+++ b/mediator/nais/nais.yaml
@@ -54,7 +54,7 @@ spec:
         - application: dp-innsyn
         - application: dp-dagpenger
         {{#if wonderwalled}}
-        - application: azure-token-generator
+        - application: wonderwalled-idporten
           namespace: aura
         {{/if}}
     outbound:


### PR DESCRIPTION
Forrige PR var ikke helt riktig. Trenger egentlig wonderwalled-idporten for å hente access_token for idporten bruker.